### PR TITLE
Update greaterThanOrEqual to ensure argument 'other' is a Long

### DIFF
--- a/dist/Long.js
+++ b/dist/Long.js
@@ -564,6 +564,8 @@
      * @expose
      */
     Long.prototype.greaterThanOrEqual = function(other) {
+        if (!Long.isLong(other))
+            other = Long.fromValue(other);
         return this.compare(other) >= 0;
     };
 

--- a/src/Long.js
+++ b/src/Long.js
@@ -564,6 +564,8 @@
      * @expose
      */
     Long.prototype.greaterThanOrEqual = function(other) {
+        if (!Long.isLong(other))
+            other = Long.fromValue(other);
         return this.compare(other) >= 0;
     };
 


### PR DESCRIPTION
Modified greaterThanOrEqual to follow the same pattern as lessThan, lessThanOrEqual, greaterThan, etc. so that the argument to the function is converted to a Long if it is not one already.