### PR TITLE
Assign names to anonymous functions for profiling

### DIFF
--- a/src/Long.js
+++ b/src/Long.js
@@ -8,7 +8,7 @@
  * @param {boolean=} unsigned Whether unsigned or not, defaults to `false` for signed
  * @constructor
  */
-var Long = function(low, high, unsigned) {
+var Long = function Long(low, high, unsigned) {
 
     /**
      * The low 32 bits as a signed value.
@@ -70,7 +70,7 @@ Object.defineProperty(Long.prototype, "__isLong__", {
  * @returns {boolean}
  * @expose
  */
-Long.isLong = function(obj) {
+Long.isLong = function isLong(obj) {
     return (obj && obj["__isLong__"]) === true;
 };
 
@@ -95,7 +95,7 @@ var UINT_CACHE = {};
  * @returns {!Long} The corresponding Long value
  * @expose
  */
-Long.fromInt = function(value, unsigned) {
+Long.fromInt = function fromInt(value, unsigned) {
     var obj, cachedObj;
     if (!unsigned) {
         value = value | 0;
@@ -129,7 +129,7 @@ Long.fromInt = function(value, unsigned) {
  * @returns {!Long} The corresponding Long value
  * @expose
  */
-Long.fromNumber = function(value, unsigned) {
+Long.fromNumber = function fromNumber(value, unsigned) {
     unsigned = !!unsigned;
     if (isNaN(value) || !isFinite(value))
         return Long.ZERO;
@@ -153,7 +153,7 @@ Long.fromNumber = function(value, unsigned) {
  * @returns {!Long} The corresponding Long value
  * @expose
  */
-Long.fromBits = function(lowBits, highBits, unsigned) {
+Long.fromBits = function fromBits(lowBits, highBits, unsigned) {
     return new Long(lowBits, highBits, unsigned);
 };
 
@@ -165,7 +165,7 @@ Long.fromBits = function(lowBits, highBits, unsigned) {
  * @returns {!Long} The corresponding Long value
  * @expose
  */
-Long.fromString = function(str, unsigned, radix) {
+Long.fromString = function fromString(str, unsigned, radix) {
     if (str.length === 0)
         throw Error('number format error: empty string');
     if (str === "NaN" || str === "Infinity" || str === "+Infinity" || str === "-Infinity")
@@ -209,7 +209,7 @@ Long.fromString = function(str, unsigned, radix) {
  * @returns {!Long}
  * @expose
  */
-Long.fromValue = function(val) {
+Long.fromValue = function fromValue(val) {
     if (val /* is compatible */ instanceof Long)
         return val;
     if (typeof val === 'number')
@@ -326,7 +326,7 @@ Long.MIN_VALUE = Long.fromBits(0, 0x80000000|0, false);
  * @returns {number}
  * @expose
  */
-Long.prototype.toInt = function() {
+Long.prototype.toInt = function toInt() {
     return this.unsigned ? this.low >>> 0 : this.low;
 };
 
@@ -335,7 +335,7 @@ Long.prototype.toInt = function() {
  * @returns {number}
  * @expose
  */
-Long.prototype.toNumber = function() {
+Long.prototype.toNumber = function toNumber() {
     if (this.unsigned) {
         return ((this.high >>> 0) * TWO_PWR_32_DBL) + (this.low >>> 0);
     }
@@ -350,7 +350,7 @@ Long.prototype.toNumber = function() {
  * @throws {RangeError} If `radix` is out of range
  * @expose
  */
-Long.prototype.toString = function(radix) {
+Long.prototype.toString = function toString(radix) {
     radix = radix || 10;
     if (radix < 2 || 36 < radix)
         throw RangeError('radix out of range: ' + radix);
@@ -394,7 +394,7 @@ Long.prototype.toString = function(radix) {
  * @returns {number} Signed high bits
  * @expose
  */
-Long.prototype.getHighBits = function() {
+Long.prototype.getHighBits = function getHighBits() {
     return this.high;
 };
 
@@ -403,7 +403,7 @@ Long.prototype.getHighBits = function() {
  * @returns {number} Unsigned high bits
  * @expose
  */
-Long.prototype.getHighBitsUnsigned = function() {
+Long.prototype.getHighBitsUnsigned = function getHighBitsUnsigned() {
     return this.high >>> 0;
 };
 
@@ -412,7 +412,7 @@ Long.prototype.getHighBitsUnsigned = function() {
  * @returns {number} Signed low bits
  * @expose
  */
-Long.prototype.getLowBits = function() {
+Long.prototype.getLowBits = function getLowBits() {
     return this.low;
 };
 
@@ -421,7 +421,7 @@ Long.prototype.getLowBits = function() {
  * @returns {number} Unsigned low bits
  * @expose
  */
-Long.prototype.getLowBitsUnsigned = function() {
+Long.prototype.getLowBitsUnsigned = function getLowBitsUnsigned() {
     return this.low >>> 0;
 };
 
@@ -430,7 +430,7 @@ Long.prototype.getLowBitsUnsigned = function() {
  * @returns {number}
  * @expose
  */
-Long.prototype.getNumBitsAbs = function() {
+Long.prototype.getNumBitsAbs = function getNumBitsAbs() {
     if (this.isNegative()) // Unsigned Longs are never negative
         return this.equals(Long.MIN_VALUE) ? 64 : this.negate().getNumBitsAbs();
     var val = this.high != 0 ? this.high : this.low;
@@ -445,7 +445,7 @@ Long.prototype.getNumBitsAbs = function() {
  * @returns {boolean}
  * @expose
  */
-Long.prototype.isZero = function() {
+Long.prototype.isZero = function isZero() {
     return this.high === 0 && this.low === 0;
 };
 
@@ -454,7 +454,7 @@ Long.prototype.isZero = function() {
  * @returns {boolean}
  * @expose
  */
-Long.prototype.isNegative = function() {
+Long.prototype.isNegative = function isNegative() {
     return !this.unsigned && this.high < 0;
 };
 
@@ -463,7 +463,7 @@ Long.prototype.isNegative = function() {
  * @returns {boolean}
  * @expose
  */
-Long.prototype.isPositive = function() {
+Long.prototype.isPositive = function isPositive() {
     return this.unsigned || this.high >= 0;
 };
 
@@ -472,7 +472,7 @@ Long.prototype.isPositive = function() {
  * @returns {boolean}
  * @expose
  */
-Long.prototype.isOdd = function() {
+Long.prototype.isOdd = function isOdd() {
     return (this.low & 1) === 1;
 };
 
@@ -481,7 +481,7 @@ Long.prototype.isOdd = function() {
  * @returns {boolean}
  * @expose
  */
-Long.prototype.isEven = function() {
+Long.prototype.isEven = function isEven() {
     return (this.low & 1) === 0;
 };
 
@@ -491,7 +491,7 @@ Long.prototype.isEven = function() {
  * @returns {boolean}
  * @expose
  */
-Long.prototype.equals = function(other) {
+Long.prototype.equals = function equals(other) {
     if (!Long.isLong(other))
         other = Long.fromValue(other);
     if (this.unsigned !== other.unsigned && (this.high >>> 31) === 1 && (other.high >>> 31) === 1)
@@ -505,7 +505,7 @@ Long.prototype.equals = function(other) {
  * @returns {boolean}
  * @expose
  */
-Long.prototype.notEquals = function(other) {
+Long.prototype.notEquals = function notEquals(other) {
     return !this.equals(/* validates */ other);
 };
 
@@ -515,7 +515,7 @@ Long.prototype.notEquals = function(other) {
  * @returns {boolean}
  * @expose
  */
-Long.prototype.lessThan = function(other) {
+Long.prototype.lessThan = function lessThan(other) {
     return this.compare(/* validates */ other) < 0;
 };
 
@@ -525,7 +525,7 @@ Long.prototype.lessThan = function(other) {
  * @returns {boolean}
  * @expose
  */
-Long.prototype.lessThanOrEqual = function(other) {
+Long.prototype.lessThanOrEqual = function lessThanOrEqual(other) {
     return this.compare(/* validates */ other) <= 0;
 };
 
@@ -535,7 +535,7 @@ Long.prototype.lessThanOrEqual = function(other) {
  * @returns {boolean}
  * @expose
  */
-Long.prototype.greaterThan = function(other) {
+Long.prototype.greaterThan = function greaterThan(other) {
     return this.compare(/* validates */ other) > 0;
 };
 
@@ -545,7 +545,7 @@ Long.prototype.greaterThan = function(other) {
  * @returns {boolean}
  * @expose
  */
-Long.prototype.greaterThanOrEqual = function(other) {
+Long.prototype.greaterThanOrEqual = function greaterThanOrEqual(other) {
     return this.compare(/* validates */ other) >= 0;
 };
 
@@ -556,7 +556,7 @@ Long.prototype.greaterThanOrEqual = function(other) {
  *  if the given one is greater
  * @expose
  */
-Long.prototype.compare = function(other) {
+Long.prototype.compare = function compare(other) {
     if (!Long.isLong(other))
         other = Long.fromValue(other);
     if (this.equals(other))
@@ -579,7 +579,7 @@ Long.prototype.compare = function(other) {
  * @returns {!Long} Negated Long
  * @expose
  */
-Long.prototype.negate = function() {
+Long.prototype.negate = function negate() {
     if (!this.unsigned && this.equals(Long.MIN_VALUE))
         return Long.MIN_VALUE;
     return this.not().add(Long.ONE);
@@ -591,7 +591,7 @@ Long.prototype.negate = function() {
  * @returns {!Long} Sum
  * @expose
  */
-Long.prototype.add = function(addend) {
+Long.prototype.add = function add(addend) {
     if (!Long.isLong(addend))
         addend = Long.fromValue(addend);
 
@@ -628,7 +628,7 @@ Long.prototype.add = function(addend) {
  * @returns {!Long} Difference
  * @expose
  */
-Long.prototype.subtract = function(subtrahend) {
+Long.prototype.subtract = function subtract(subtrahend) {
     if (!Long.isLong(subtrahend))
         subtrahend = Long.fromValue(subtrahend);
     return this.add(subtrahend.negate());
@@ -640,7 +640,7 @@ Long.prototype.subtract = function(subtrahend) {
  * @returns {!Long} Product
  * @expose
  */
-Long.prototype.multiply = function(multiplier) {
+Long.prototype.multiply = function multiply(multiplier) {
     if (this.isZero())
         return Long.ZERO;
     if (!Long.isLong(multiplier))
@@ -707,7 +707,7 @@ Long.prototype.multiply = function(multiplier) {
  * @returns {!Long} Quotient
  * @expose
  */
-Long.prototype.div = function(divisor) {
+Long.prototype.div = function div(divisor) {
     if (!Long.isLong(divisor))
         divisor = Long.fromValue(divisor);
     if (divisor.isZero())
@@ -796,7 +796,7 @@ Long.prototype.modulo = function(divisor) {
  * @returns {!Long}
  * @expose
  */
-Long.prototype.not = function() {
+Long.prototype.not = function not() {
     return Long.fromBits(~this.low, ~this.high, this.unsigned);
 };
 
@@ -806,7 +806,7 @@ Long.prototype.not = function() {
  * @returns {!Long}
  * @expose
  */
-Long.prototype.and = function(other) {
+Long.prototype.and = function and(other) {
     if (!Long.isLong(other))
         other = Long.fromValue(other);
     return Long.fromBits(this.low & other.low, this.high & other.high, this.unsigned);
@@ -818,7 +818,7 @@ Long.prototype.and = function(other) {
  * @returns {!Long}
  * @expose
  */
-Long.prototype.or = function(other) {
+Long.prototype.or = function or(other) {
     if (!Long.isLong(other))
         other = Long.fromValue(other);
     return Long.fromBits(this.low | other.low, this.high | other.high, this.unsigned);
@@ -830,7 +830,7 @@ Long.prototype.or = function(other) {
  * @returns {!Long}
  * @expose
  */
-Long.prototype.xor = function(other) {
+Long.prototype.xor = function xor(other) {
     if (!Long.isLong(other))
         other = Long.fromValue(other);
     return Long.fromBits(this.low ^ other.low, this.high ^ other.high, this.unsigned);
@@ -859,7 +859,7 @@ Long.prototype.shiftLeft = function(numBits) {
  * @returns {!Long} Shifted Long
  * @expose
  */
-Long.prototype.shiftRight = function(numBits) {
+Long.prototype.shiftRight = function shiftRight(numBits) {
     if (Long.isLong(numBits))
         numBits = numBits.toInt();
     if ((numBits &= 63) === 0)
@@ -876,7 +876,7 @@ Long.prototype.shiftRight = function(numBits) {
  * @returns {!Long} Shifted Long
  * @expose
  */
-Long.prototype.shiftRightUnsigned = function(numBits) {
+Long.prototype.shiftRightUnsigned = function shiftRightUnsigned(numBits) {
     if (Long.isLong(numBits))
         numBits = numBits.toInt();
     numBits &= 63;
@@ -899,7 +899,7 @@ Long.prototype.shiftRightUnsigned = function(numBits) {
  * @returns {!Long} Signed long
  * @expose
  */
-Long.prototype.toSigned = function() {
+Long.prototype.toSigned = function toSigned() {
     if (!this.unsigned)
         return this;
     return new Long(this.low, this.high, false);
@@ -910,7 +910,7 @@ Long.prototype.toSigned = function() {
  * @returns {!Long} Unsigned long
  * @expose
  */
-Long.prototype.toUnsigned = function() {
+Long.prototype.toUnsigned = function toUnsigned() {
     if (this.unsigned)
         return this;
     return new Long(this.low, this.high, true);


### PR DESCRIPTION
My team is evaluating the use of long for i64 in https://github.com/uber/thriftrw. This library is clearly the closest to our needs.

We use profiling tools like [stap](https://github.com/uber/node-stap) to measure hot code on production systems. As a consequence, we require all methods to have names.

We expect using long as the internal i64 representation to be a performance win over using buffers.