### PR TITLE
Make isLong a TypeScript type guard.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -99,7 +99,7 @@ declare class Long {
     /**
      * Tests if the specified object is a Long.
      */
-    static isLong(obj: any): boolean;
+    static isLong(obj: any): obj is Long;
 
     /**
      * Converts the specified value to a Long.


### PR DESCRIPTION
This lets TypeScript narrow types when it can, making type checking and
code completion a bit more useful

For example:

```js
function makeNumber(x: number | Long): number {
  if (isLong(x)) {
    // If isLong wasn't a type guard, this would cause a compilation
    // error, since TS wouldn't know that x was specifically a Long.
    return x.toNumber()
  }
  return x
}
```

For more info:

  https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards