### PR TITLE
update typescript definitions and the export syntax in javascript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,9 @@
-export default class Long {
+export = Long;
+export as namespace Long;
+
+declare namespace Long { }
+
+declare class Long {
     /**
      * Constructs a 64 bit two's-complement integer, given its low and high 32 bit values as signed integers. See the from* functions below for more convenient ways of constructing Longs.
      */
@@ -85,12 +90,12 @@ export default class Long {
     static fromBytes(bytes: number[], unsigned?: boolean, le?: boolean): Long;
 
     /**
-     * Creates a Long from its big endian byte representation.
+     * Creates a Long from its little endian byte representation.
      */
     static fromBytesLE(bytes: number[], unsigned?: boolean): Long;
 
     /**
-     * Creates a Long from its little endian byte representation.
+     * Creates a Long from its big endian byte representation.
      */
     static fromBytesBE(bytes: number[], unsigned?: boolean): Long;
 
@@ -402,5 +407,3 @@ export default class Long {
      */
     xor(other: Long | number | string): Long;
 }
-
-export { Long };

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,4 @@
-export default Long;
-
-declare class Long {
+export default class Long {
     /**
      * Constructs a 64 bit two's-complement integer, given its low and high 32 bit values as signed integers. See the from* functions below for more convenient ways of constructing Longs.
      */
@@ -87,7 +85,7 @@ declare class Long {
     static fromBytes(bytes: number[], unsigned?: boolean, le?: boolean): Long;
 
     /**
-     * Creates a Long from its little endian byte representation.
+     * Creates a Long from its big endian byte representation.
      */
     static fromBytesLE(bytes: number[], unsigned?: boolean): Long;
 
@@ -404,3 +402,5 @@ declare class Long {
      */
     xor(other: Long | number | string): Long;
 }
+
+export { Long };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "long",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "author": "Daniel Wirtz <dcode@dcode.io>",
     "description": "A Long class for representing a 64-bit two's-complement integer value.",
     "main": "src/long.js",

--- a/src/long.js
+++ b/src/long.js
@@ -1,6 +1,4 @@
 module.exports = Long;
-module.exports.default = Long;
-module.exports.Long = Long;
 
 /**
  * wasm optimizations, to do native i64 multiplication and divide

--- a/src/long.js
+++ b/src/long.js
@@ -1,4 +1,6 @@
 module.exports = Long;
+module.exports.default = Long;
+module.exports.Long = Long;
 
 /**
  * wasm optimizations, to do native i64 multiplication and divide


### PR DESCRIPTION
- updated typescript type definitions to export the `Long` class along with the `default` export
- Added `default` and `Long` as properties on `module.exports`. This does not cause any breaking changes and also ensure that someone can import the packages in TypeScript as follows
- `import Long from "long";`
- `import { Long } from "long";`