### PR TITLE
Don't sign-extend unsigned input in fromInt().

### DIFF
--- a/src/long.js
+++ b/src/long.js
@@ -125,7 +125,7 @@ function fromInt(value, unsigned) {
             if (cachedObj)
                 return cachedObj;
         }
-        obj = fromBits(value, (value | 0) < 0 ? -1 : 0, true);
+        obj = fromBits(value, 0, true);
         if (cache)
             UINT_CACHE[value] = obj;
         return obj;


### PR DESCRIPTION
fromInt() incorrectly sign-extends unsigned inputs, leading to an unsigned 32-bit input in the range 0x80000000 to 0xFFFFFFFF being converted to a Long in the range 0xFFFFFFFF80000000 to 0xFFFFFFFFFFFFFFFF.