### PR TITLE
Add support for BigInt (closes #82)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ API
 * Long.**fromInt**(value: `number`, unsigned?: `boolean`): `Long`<br />
   Returns a Long representing the given 32 bit integer value.
 
+* Long.**fromBigInt**(value: `bigint`, unsigned?: `boolean`): `Long`<br />
+  Returns a Long representing the given BigInt.
+
 * Long.**fromNumber**(value: `number`, unsigned?: `boolean`): `Long`<br />
   Returns a Long representing the given value, provided that it is a finite number. Otherwise, zero is returned.
 
@@ -133,19 +136,19 @@ API
 
 ### Methods
 
-* Long#**add**(addend: `Long | number | string`): `Long`<br />
+* Long#**add**(addend: `Long | number | string | bigint`): `Long`<br />
   Returns the sum of this and the specified Long.
 
-* Long#**and**(other: `Long | number | string`): `Long`<br />
+* Long#**and**(other: `Long | number | string | bigint`): `Long`<br />
   Returns the bitwise AND of this Long and the specified.
 
-* Long#**compare**/**comp**(other: `Long | number | string`): `number`<br />
+* Long#**compare**/**comp**(other: `Long | number | string | bigint`): `number`<br />
   Compares this Long's value with the specified's. Returns `0` if they are the same, `1` if the this is greater and `-1` if the given one is greater.
 
-* Long#**divide**/**div**(divisor: `Long | number | string`): `Long`<br />
+* Long#**divide**/**div**(divisor: `Long | number | string | bigint`): `Long`<br />
   Returns this Long divided by the specified.
 
-* Long#**equals**/**eq**(other: `Long | number | string`): `boolean`<br />
+* Long#**equals**/**eq**(other: `Long | number | string | bigint`): `boolean`<br />
   Tests if this Long's value equals the specified's.
 
 * Long#**getHighBits**(): `number`<br />
@@ -163,10 +166,10 @@ API
 * Long#**getNumBitsAbs**(): `number`<br />
   Gets the number of bits needed to represent the absolute value of this Long.
 
-* Long#**greaterThan**/**gt**(other: `Long | number | string`): `boolean`<br />
+* Long#**greaterThan**/**gt**(other: `Long | number | string | bigint`): `boolean`<br />
   Tests if this Long's value is greater than the specified's.
 
-* Long#**greaterThanOrEqual**/**gte**/**ge**(other: `Long | number | string`): `boolean`<br />
+* Long#**greaterThanOrEqual**/**gte**/**ge**(other: `Long | number | string | bigint`): `boolean`<br />
   Tests if this Long's value is greater than or equal the specified's.
 
 * Long#**isEven**(): `boolean`<br />
@@ -184,16 +187,16 @@ API
 * Long#**isZero**/**eqz**(): `boolean`<br />
   Tests if this Long's value equals zero.
 
-* Long#**lessThan**/**lt**(other: `Long | number | string`): `boolean`<br />
+* Long#**lessThan**/**lt**(other: `Long | number | string | bigint`): `boolean`<br />
   Tests if this Long's value is less than the specified's.
 
-* Long#**lessThanOrEqual**/**lte**/**le**(other: `Long | number | string`): `boolean`<br />
+* Long#**lessThanOrEqual**/**lte**/**le**(other: `Long | number | string | bigint`): `boolean`<br />
   Tests if this Long's value is less than or equal the specified's.
 
-* Long#**modulo**/**mod**/**rem**(divisor: `Long | number | string`): `Long`<br />
+* Long#**modulo**/**mod**/**rem**(divisor: `Long | number | string | bigint`): `Long`<br />
   Returns this Long modulo the specified.
 
-* Long#**multiply**/**mul**(multiplier: `Long | number | string`): `Long`<br />
+* Long#**multiply**/**mul**(multiplier: `Long | number | string | bigint`): `Long`<br />
   Returns the product of this and the specified Long.
 
 * Long#**negate**/**neg**(): `Long`<br />
@@ -208,28 +211,28 @@ API
 * Long#**countTrailingZeros**/**ctz**(): `number`<br />
   Returns count trailing zeros of this Long.
 
-* Long#**notEquals**/**neq**/**ne**(other: `Long | number | string`): `boolean`<br />
+* Long#**notEquals**/**neq**/**ne**(other: `Long | number | string | bigint`): `boolean`<br />
   Tests if this Long's value differs from the specified's.
 
-* Long#**or**(other: `Long | number | string`): `Long`<br />
+* Long#**or**(other: `Long | number | string | bigint`): `Long`<br />
   Returns the bitwise OR of this Long and the specified.
 
-* Long#**shiftLeft**/**shl**(numBits: `Long | number | string`): `Long`<br />
+* Long#**shiftLeft**/**shl**(numBits: `Long | number | string | bigint`): `Long`<br />
   Returns this Long with bits shifted to the left by the given amount.
 
-* Long#**shiftRight**/**shr**(numBits: `Long | number | string`): `Long`<br />
+* Long#**shiftRight**/**shr**(numBits: `Long | number | string | bigint`): `Long`<br />
   Returns this Long with bits arithmetically shifted to the right by the given amount.
 
-* Long#**shiftRightUnsigned**/**shru**/**shr_u**(numBits: `Long | number | string`): `Long`<br />
+* Long#**shiftRightUnsigned**/**shru**/**shr_u**(numBits: `Long | number | string | bigint`): `Long`<br />
   Returns this Long with bits logically shifted to the right by the given amount.
 
-* Long#**rotateLeft**/**rotl**(numBits: `Long | number | string`): `Long`<br />
+* Long#**rotateLeft**/**rotl**(numBits: `Long | number | string | bigint`): `Long`<br />
   Returns this Long with bits rotated to the left by the given amount.
 
-* Long#**rotateRight**/**rotr**(numBits: `Long | number | string`): `Long`<br />
+* Long#**rotateRight**/**rotr**(numBits: `Long | number | string | bigint`): `Long`<br />
   Returns this Long with bits rotated to the right by the given amount.
 
-* Long#**subtract**/**sub**(subtrahend: `Long | number | string`): `Long`<br />
+* Long#**subtract**/**sub**(subtrahend: `Long | number | string | bigint`): `Long`<br />
   Returns the difference of this and the specified Long.
 
 * Long#**toBytes**(le?: `boolean`): `number[]`<br />
@@ -244,6 +247,9 @@ API
 * Long#**toInt**(): `number`<br />
   Converts the Long to a 32 bit integer, assuming it is a 32 bit integer.
 
+* Long#**toBigInt**(): `bigint`<br />
+  Converts the Long to a BigInt.
+
 * Long#**toNumber**(): `number`<br />
   Converts the Long to a the nearest floating-point representation of this value (double, 53 bit mantissa).
 
@@ -256,7 +262,7 @@ API
 * Long#**toUnsigned**(): `Long`<br />
   Converts this Long to unsigned.
 
-* Long#**xor**(other: `Long | number | string`): `Long`<br />
+* Long#**xor**(other: `Long | number | string | bigint`): `Long`<br />
   Returns the bitwise XOR of this Long and the given one.
 
 WebAssembly support

--- a/index.d.ts
+++ b/index.d.ts
@@ -70,6 +70,11 @@ declare class Long {
   static fromInt(value: number, unsigned?: boolean): Long;
 
   /**
+   * Returns a Long representing the given BigInt.
+   */
+  static fromBigInt(value: bigint, unsigned?: boolean): Long;
+
+  /**
    * Returns a Long representing the given value, provided that it is a finite number. Otherwise, zero is returned.
    */
   static fromNumber(value: number, unsigned?: boolean): Long;
@@ -102,47 +107,47 @@ declare class Long {
   /**
    * Converts the specified value to a Long.
    */
-  static fromValue(val: Long | number | string | { low: number, high: number, unsigned: boolean }, unsigned?: boolean): Long;
+  static fromValue(val: Long | number | string | bigint | { low: number, high: number, unsigned: boolean }, unsigned?: boolean): Long;
 
   /**
    * Returns the sum of this and the specified Long.
    */
-  add(addend: number | Long | string): Long;
+  add(addend: number | Long | string | bigint): Long;
 
   /**
    * Returns the bitwise AND of this Long and the specified.
    */
-  and(other: Long | number | string): Long;
+  and(other: Long | number | string | bigint): Long;
 
   /**
    * Compares this Long's value with the specified's.
    */
-  compare(other: Long | number | string): number;
+  compare(other: Long | number | string | bigint): number;
 
   /**
    * Compares this Long's value with the specified's.
    */
-  comp(other: Long | number | string): number;
+  comp(other: Long | number | string | bigint): number;
 
   /**
    * Returns this Long divided by the specified.
    */
-  divide(divisor: Long | number | string): Long;
+  divide(divisor: Long | number | string | bigint): Long;
 
   /**
    * Returns this Long divided by the specified.
    */
-  div(divisor: Long | number | string): Long;
+  div(divisor: Long | number | string | bigint): Long;
 
   /**
    * Tests if this Long's value equals the specified's.
    */
-  equals(other: Long | number | string): boolean;
+  equals(other: Long | number | string | bigint): boolean;
 
   /**
    * Tests if this Long's value equals the specified's.
    */
-  eq(other: Long | number | string): boolean;
+  eq(other: Long | number | string | bigint): boolean;
 
   /**
    * Gets the high 32 bits as a signed integer.
@@ -172,27 +177,27 @@ declare class Long {
   /**
    * Tests if this Long's value is greater than the specified's.
    */
-  greaterThan(other: Long | number | string): boolean;
+  greaterThan(other: Long | number | string | bigint): boolean;
 
   /**
    * Tests if this Long's value is greater than the specified's.
    */
-  gt(other: Long | number | string): boolean;
+  gt(other: Long | number | string | bigint): boolean;
 
   /**
    * Tests if this Long's value is greater than or equal the specified's.
    */
-  greaterThanOrEqual(other: Long | number | string): boolean;
+  greaterThanOrEqual(other: Long | number | string | bigint): boolean;
 
   /**
    * Tests if this Long's value is greater than or equal the specified's.
    */
-  gte(other: Long | number | string): boolean;
+  gte(other: Long | number | string | bigint): boolean;
 
   /**
    * Tests if this Long's value is greater than or equal the specified's.
    */
-  ge(other: Long | number | string): boolean;
+  ge(other: Long | number | string | bigint): boolean;
 
   /**
    * Tests if this Long's value is even.
@@ -227,52 +232,52 @@ declare class Long {
   /**
    * Tests if this Long's value is less than the specified's.
    */
-  lessThan(other: Long | number | string): boolean;
+  lessThan(other: Long | number | string | bigint): boolean;
 
   /**
    * Tests if this Long's value is less than the specified's.
    */
-  lt(other: Long | number | string): boolean;
+  lt(other: Long | number | string | bigint): boolean;
 
   /**
    * Tests if this Long's value is less than or equal the specified's.
    */
-  lessThanOrEqual(other: Long | number | string): boolean;
+  lessThanOrEqual(other: Long | number | string | bigint): boolean;
 
   /**
    * Tests if this Long's value is less than or equal the specified's.
    */
-  lte(other: Long | number | string): boolean;
+  lte(other: Long | number | string | bigint): boolean;
 
   /**
    * Tests if this Long's value is less than or equal the specified's.
    */
-  le(other: Long | number | string): boolean;
+  le(other: Long | number | string | bigint): boolean;
 
   /**
    * Returns this Long modulo the specified.
    */
-  modulo(other: Long | number | string): Long;
+  modulo(other: Long | number | string | bigint): Long;
 
   /**
    * Returns this Long modulo the specified.
    */
-  mod(other: Long | number | string): Long;
+  mod(other: Long | number | string | bigint): Long;
 
   /**
    * Returns this Long modulo the specified.
    */
-  rem(other: Long | number | string): Long;
+  rem(other: Long | number | string | bigint): Long;
 
   /**
    * Returns the product of this and the specified Long.
    */
-  multiply(multiplier: Long | number | string): Long;
+  multiply(multiplier: Long | number | string | bigint): Long;
 
   /**
    * Returns the product of this and the specified Long.
    */
-  mul(multiplier: Long | number | string): Long;
+  mul(multiplier: Long | number | string | bigint): Long;
 
   /**
    * Negates this Long's value.
@@ -312,22 +317,22 @@ declare class Long {
   /**
    * Tests if this Long's value differs from the specified's.
    */
-  notEquals(other: Long | number | string): boolean;
+  notEquals(other: Long | number | string | bigint): boolean;
 
   /**
    * Tests if this Long's value differs from the specified's.
    */
-  neq(other: Long | number | string): boolean;
+  neq(other: Long | number | string | bigint): boolean;
 
   /**
    * Tests if this Long's value differs from the specified's.
    */
-  ne(other: Long | number | string): boolean;
+  ne(other: Long | number | string | bigint): boolean;
 
   /**
    * Returns the bitwise OR of this Long and the specified.
    */
-  or(other: Long | number | string): Long;
+  or(other: Long | number | string | bigint): Long;
 
   /**
    * Returns this Long with bits shifted to the left by the given amount.
@@ -387,17 +392,22 @@ declare class Long {
   /**
    * Returns the difference of this and the specified Long.
    */
-  subtract(subtrahend: number | Long | string): Long;
+  subtract(subtrahend: number | Long | string | bigint): Long;
 
   /**
    * Returns the difference of this and the specified Long.
    */
-  sub(subtrahend: number | Long | string): Long;
+  sub(subtrahend: number | Long | string | bigint): Long;
 
   /**
    * Converts the Long to a 32 bit integer, assuming it is a 32 bit integer.
    */
   toInt(): number;
+
+  /**
+   * Converts the Long to a BigInt.
+   */
+  toBigInt(): bigint;
 
   /**
    * Converts the Long to a the nearest floating-point representation of this value (double, 53 bit mantissa).
@@ -440,7 +450,7 @@ declare class Long {
   /**
    * Returns the bitwise XOR of this Long and the given one.
    */
-  xor(other: Long | number | string): Long;
+  xor(other: Long | number | string | bigint): Long;
 }
 
 export = Long; // compatible with `import Long from "long"`

--- a/index.js
+++ b/index.js
@@ -297,8 +297,27 @@ function fromString(str, unsigned, radix) {
 Long.fromString = fromString;
 
 /**
+ * @param {bigint} value
+ * @param {(boolean|number)=} unsigned
+ * @returns {!Long}
+ * @inner
+ */
+function fromBigInt(value, unsigned) {
+  return fromString(value.toString(), unsigned, 10)
+}
+
+/**
+ * Returns a Long representing the given BigInt.
  * @function
- * @param {!Long|number|string|!{low: number, high: number, unsigned: boolean}} val
+ * @param {bigint} value The BigInt representation of the Long
+ * @param {(boolean|number)=} unsigned Whether unsigned or not, defaults to signed
+ * @returns {!Long} The corresponding Long value
+ */
+Long.fromBigInt = fromBigInt;
+
+/**
+ * @function
+ * @param {!Long|number|string|bigint|!{low: number, high: number, unsigned: boolean}} val
  * @param {boolean=} unsigned
  * @returns {!Long}
  * @inner
@@ -308,6 +327,8 @@ function fromValue(val, unsigned) {
     return fromNumber(val, unsigned);
   if (typeof val === 'string')
     return fromString(val, unsigned);
+  if (typeof val === 'bigint')
+    return fromBigInt(val, unsigned);
   // Throws for non-objects, converts non-instanceof Long:
   return fromBits(val.low, val.high, typeof unsigned === 'boolean' ? unsigned : val.unsigned);
 }
@@ -315,7 +336,7 @@ function fromValue(val, unsigned) {
 /**
  * Converts the specified value to a Long using the appropriate from* function for its type.
  * @function
- * @param {!Long|number|string|!{low: number, high: number, unsigned: boolean}} val Value
+ * @param {!Long|number|string|bigint|!{low: number, high: number, unsigned: boolean}} val Value
  * @param {boolean=} unsigned Whether unsigned or not, defaults to signed
  * @returns {!Long}
  */
@@ -475,6 +496,15 @@ var LongPrototype = Long.prototype;
  */
 LongPrototype.toInt = function toInt() {
   return this.unsigned ? this.low >>> 0 : this.low;
+};
+
+/**
+ * Converts the Long to a BigInt.
+ * @this {!Long}
+ * @returns {bigint}
+ */
+ LongPrototype.toBigInt = function toBigInt() {
+  return BigInt(this.toString())
 };
 
 /**
@@ -639,7 +669,7 @@ LongPrototype.isEven = function isEven() {
 /**
  * Tests if this Long's value equals the specified's.
  * @this {!Long}
- * @param {!Long|number|string} other Other value
+ * @param {!Long|number|string|bigint} other Other value
  * @returns {boolean}
  */
 LongPrototype.equals = function equals(other) {
@@ -653,7 +683,7 @@ LongPrototype.equals = function equals(other) {
 /**
  * Tests if this Long's value equals the specified's. This is an alias of {@link Long#equals}.
  * @function
- * @param {!Long|number|string} other Other value
+ * @param {!Long|number|string|bigint} other Other value
  * @returns {boolean}
  */
 LongPrototype.eq = LongPrototype.equals;
@@ -661,7 +691,7 @@ LongPrototype.eq = LongPrototype.equals;
 /**
  * Tests if this Long's value differs from the specified's.
  * @this {!Long}
- * @param {!Long|number|string} other Other value
+ * @param {!Long|number|string|bigint} other Other value
  * @returns {boolean}
  */
 LongPrototype.notEquals = function notEquals(other) {
@@ -671,7 +701,7 @@ LongPrototype.notEquals = function notEquals(other) {
 /**
  * Tests if this Long's value differs from the specified's. This is an alias of {@link Long#notEquals}.
  * @function
- * @param {!Long|number|string} other Other value
+ * @param {!Long|number|string|bigint} other Other value
  * @returns {boolean}
  */
 LongPrototype.neq = LongPrototype.notEquals;
@@ -679,7 +709,7 @@ LongPrototype.neq = LongPrototype.notEquals;
 /**
  * Tests if this Long's value differs from the specified's. This is an alias of {@link Long#notEquals}.
  * @function
- * @param {!Long|number|string} other Other value
+ * @param {!Long|number|string|bigint} other Other value
  * @returns {boolean}
  */
 LongPrototype.ne = LongPrototype.notEquals;
@@ -687,7 +717,7 @@ LongPrototype.ne = LongPrototype.notEquals;
 /**
  * Tests if this Long's value is less than the specified's.
  * @this {!Long}
- * @param {!Long|number|string} other Other value
+ * @param {!Long|number|string|bigint} other Other value
  * @returns {boolean}
  */
 LongPrototype.lessThan = function lessThan(other) {
@@ -697,7 +727,7 @@ LongPrototype.lessThan = function lessThan(other) {
 /**
  * Tests if this Long's value is less than the specified's. This is an alias of {@link Long#lessThan}.
  * @function
- * @param {!Long|number|string} other Other value
+ * @param {!Long|number|string|bigint} other Other value
  * @returns {boolean}
  */
 LongPrototype.lt = LongPrototype.lessThan;
@@ -705,7 +735,7 @@ LongPrototype.lt = LongPrototype.lessThan;
 /**
  * Tests if this Long's value is less than or equal the specified's.
  * @this {!Long}
- * @param {!Long|number|string} other Other value
+ * @param {!Long|number|string|bigint} other Other value
  * @returns {boolean}
  */
 LongPrototype.lessThanOrEqual = function lessThanOrEqual(other) {
@@ -715,7 +745,7 @@ LongPrototype.lessThanOrEqual = function lessThanOrEqual(other) {
 /**
  * Tests if this Long's value is less than or equal the specified's. This is an alias of {@link Long#lessThanOrEqual}.
  * @function
- * @param {!Long|number|string} other Other value
+ * @param {!Long|number|string|bigint} other Other value
  * @returns {boolean}
  */
 LongPrototype.lte = LongPrototype.lessThanOrEqual;
@@ -723,7 +753,7 @@ LongPrototype.lte = LongPrototype.lessThanOrEqual;
 /**
  * Tests if this Long's value is less than or equal the specified's. This is an alias of {@link Long#lessThanOrEqual}.
  * @function
- * @param {!Long|number|string} other Other value
+ * @param {!Long|number|string|bigint} other Other value
  * @returns {boolean}
  */
 LongPrototype.le = LongPrototype.lessThanOrEqual;
@@ -731,7 +761,7 @@ LongPrototype.le = LongPrototype.lessThanOrEqual;
 /**
  * Tests if this Long's value is greater than the specified's.
  * @this {!Long}
- * @param {!Long|number|string} other Other value
+ * @param {!Long|number|string|bigint} other Other value
  * @returns {boolean}
  */
 LongPrototype.greaterThan = function greaterThan(other) {
@@ -741,7 +771,7 @@ LongPrototype.greaterThan = function greaterThan(other) {
 /**
  * Tests if this Long's value is greater than the specified's. This is an alias of {@link Long#greaterThan}.
  * @function
- * @param {!Long|number|string} other Other value
+ * @param {!Long|number|string|bigint} other Other value
  * @returns {boolean}
  */
 LongPrototype.gt = LongPrototype.greaterThan;
@@ -749,7 +779,7 @@ LongPrototype.gt = LongPrototype.greaterThan;
 /**
  * Tests if this Long's value is greater than or equal the specified's.
  * @this {!Long}
- * @param {!Long|number|string} other Other value
+ * @param {!Long|number|string|bigint} other Other value
  * @returns {boolean}
  */
 LongPrototype.greaterThanOrEqual = function greaterThanOrEqual(other) {
@@ -759,7 +789,7 @@ LongPrototype.greaterThanOrEqual = function greaterThanOrEqual(other) {
 /**
  * Tests if this Long's value is greater than or equal the specified's. This is an alias of {@link Long#greaterThanOrEqual}.
  * @function
- * @param {!Long|number|string} other Other value
+ * @param {!Long|number|string|bigint} other Other value
  * @returns {boolean}
  */
 LongPrototype.gte = LongPrototype.greaterThanOrEqual;
@@ -767,7 +797,7 @@ LongPrototype.gte = LongPrototype.greaterThanOrEqual;
 /**
  * Tests if this Long's value is greater than or equal the specified's. This is an alias of {@link Long#greaterThanOrEqual}.
  * @function
- * @param {!Long|number|string} other Other value
+ * @param {!Long|number|string|bigint} other Other value
  * @returns {boolean}
  */
 LongPrototype.ge = LongPrototype.greaterThanOrEqual;
@@ -775,7 +805,7 @@ LongPrototype.ge = LongPrototype.greaterThanOrEqual;
 /**
  * Compares this Long's value with the specified's.
  * @this {!Long}
- * @param {!Long|number|string} other Other value
+ * @param {!Long|number|string|bigint} other Other value
  * @returns {number} 0 if they are the same, 1 if the this is greater and -1
  *  if the given one is greater
  */
@@ -800,7 +830,7 @@ LongPrototype.compare = function compare(other) {
 /**
  * Compares this Long's value with the specified's. This is an alias of {@link Long#compare}.
  * @function
- * @param {!Long|number|string} other Other value
+ * @param {!Long|number|string|bigint} other Other value
  * @returns {number} 0 if they are the same, 1 if the this is greater and -1
  *  if the given one is greater
  */
@@ -827,7 +857,7 @@ LongPrototype.neg = LongPrototype.negate;
 /**
  * Returns the sum of this and the specified Long.
  * @this {!Long}
- * @param {!Long|number|string} addend Addend
+ * @param {!Long|number|string|bigint} addend Addend
  * @returns {!Long} Sum
  */
 LongPrototype.add = function add(addend) {
@@ -864,7 +894,7 @@ LongPrototype.add = function add(addend) {
 /**
  * Returns the difference of this and the specified Long.
  * @this {!Long}
- * @param {!Long|number|string} subtrahend Subtrahend
+ * @param {!Long|number|string|bigint} subtrahend Subtrahend
  * @returns {!Long} Difference
  */
 LongPrototype.subtract = function subtract(subtrahend) {
@@ -876,7 +906,7 @@ LongPrototype.subtract = function subtract(subtrahend) {
 /**
  * Returns the difference of this and the specified Long. This is an alias of {@link Long#subtract}.
  * @function
- * @param {!Long|number|string} subtrahend Subtrahend
+ * @param {!Long|number|string|bigint} subtrahend Subtrahend
  * @returns {!Long} Difference
  */
 LongPrototype.sub = LongPrototype.subtract;
@@ -884,7 +914,7 @@ LongPrototype.sub = LongPrototype.subtract;
 /**
  * Returns the product of this and the specified Long.
  * @this {!Long}
- * @param {!Long|number|string} multiplier Multiplier
+ * @param {!Long|number|string|bigint} multiplier Multiplier
  * @returns {!Long} Product
  */
 LongPrototype.multiply = function multiply(multiplier) {
@@ -961,7 +991,7 @@ LongPrototype.multiply = function multiply(multiplier) {
 /**
  * Returns the product of this and the specified Long. This is an alias of {@link Long#multiply}.
  * @function
- * @param {!Long|number|string} multiplier Multiplier
+ * @param {!Long|number|string|bigint} multiplier Multiplier
  * @returns {!Long} Product
  */
 LongPrototype.mul = LongPrototype.multiply;
@@ -970,7 +1000,7 @@ LongPrototype.mul = LongPrototype.multiply;
  * Returns this Long divided by the specified. The result is signed if this Long is signed or
  *  unsigned if this Long is unsigned.
  * @this {!Long}
- * @param {!Long|number|string} divisor Divisor
+ * @param {!Long|number|string|bigint} divisor Divisor
  * @returns {!Long} Quotient
  */
 LongPrototype.divide = function divide(divisor) {
@@ -1083,7 +1113,7 @@ LongPrototype.divide = function divide(divisor) {
 /**
  * Returns this Long divided by the specified. This is an alias of {@link Long#divide}.
  * @function
- * @param {!Long|number|string} divisor Divisor
+ * @param {!Long|number|string|bigint} divisor Divisor
  * @returns {!Long} Quotient
  */
 LongPrototype.div = LongPrototype.divide;
@@ -1091,7 +1121,7 @@ LongPrototype.div = LongPrototype.divide;
 /**
  * Returns this Long modulo the specified.
  * @this {!Long}
- * @param {!Long|number|string} divisor Divisor
+ * @param {!Long|number|string|bigint} divisor Divisor
  * @returns {!Long} Remainder
  */
 LongPrototype.modulo = function modulo(divisor) {
@@ -1115,7 +1145,7 @@ LongPrototype.modulo = function modulo(divisor) {
 /**
  * Returns this Long modulo the specified. This is an alias of {@link Long#modulo}.
  * @function
- * @param {!Long|number|string} divisor Divisor
+ * @param {!Long|number|string|bigint} divisor Divisor
  * @returns {!Long} Remainder
  */
 LongPrototype.mod = LongPrototype.modulo;
@@ -1123,7 +1153,7 @@ LongPrototype.mod = LongPrototype.modulo;
 /**
  * Returns this Long modulo the specified. This is an alias of {@link Long#modulo}.
  * @function
- * @param {!Long|number|string} divisor Divisor
+ * @param {!Long|number|string|bigint} divisor Divisor
  * @returns {!Long} Remainder
  */
 LongPrototype.rem = LongPrototype.modulo;
@@ -1174,7 +1204,7 @@ LongPrototype.ctz = LongPrototype.countTrailingZeros;
 /**
  * Returns the bitwise AND of this Long and the specified.
  * @this {!Long}
- * @param {!Long|number|string} other Other Long
+ * @param {!Long|number|string|bigint} other Other Long
  * @returns {!Long}
  */
 LongPrototype.and = function and(other) {
@@ -1186,7 +1216,7 @@ LongPrototype.and = function and(other) {
 /**
  * Returns the bitwise OR of this Long and the specified.
  * @this {!Long}
- * @param {!Long|number|string} other Other Long
+ * @param {!Long|number|string|bigint} other Other Long
  * @returns {!Long}
  */
 LongPrototype.or = function or(other) {
@@ -1198,7 +1228,7 @@ LongPrototype.or = function or(other) {
 /**
  * Returns the bitwise XOR of this Long and the given one.
  * @this {!Long}
- * @param {!Long|number|string} other Other Long
+ * @param {!Long|number|string|bigint} other Other Long
  * @returns {!Long}
  */
 LongPrototype.xor = function xor(other) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -7,10 +7,12 @@ var tests = [ // BEGIN TEST CASES
     var longVal = new Long(0xFFFFFFFF, 0x7FFFFFFF);
     assert.strictEqual(longVal.toNumber(), 9223372036854775807);
     assert.strictEqual(longVal.toString(), "9223372036854775807");
+    assert.strictEqual(longVal.toBigInt(), 9223372036854775807n);
 
     var longVal2 = Long.fromValue(longVal);
     assert.strictEqual(longVal2.toNumber(), 9223372036854775807);
     assert.strictEqual(longVal2.toString(), "9223372036854775807");
+    assert.strictEqual(longVal2.toBigInt(), 9223372036854775807n);
     assert.strictEqual(longVal2.unsigned, longVal.unsigned);
   },
 
@@ -30,6 +32,21 @@ var tests = [ // BEGIN TEST CASES
     // #7, obviously wrong in goog.math.Long
     assert.strictEqual(Long.fromString("zzzzzz", 36).toString(36), "zzzzzz");
     assert.strictEqual(Long.fromString("-zzzzzz", 36).toString(36), "-zzzzzz");
+  },
+
+  function testToBigInt() {
+    var longVal = Long.fromBits(0xFFFFFFFF, 0xFFFFFFFF, true);
+    assert.strictEqual(longVal.toBigInt(), 18446744073709551615n);
+  },
+
+  function testFromBigInt() {
+    var longVal = Long.fromBigInt(1311768464886809959n);
+    var ulongVal = Long.fromBigInt(1311768464886809959n, true);
+    assert.deepEqual(Long.fromBigInt(longVal.toBigInt()), longVal);
+    assert.deepEqual(Long.fromBytes([0x12, 0x34, 0x56, 0x78, 0x01, 0x23, 0x45, 0x67]), longVal);
+    assert.deepEqual(Long.fromBytes([0x12, 0x34, 0x56, 0x78, 0x01, 0x23, 0x45, 0x67], false, false), longVal);
+    assert.deepEqual(Long.fromBytes([0x67, 0x45, 0x23, 0x01, 0x78, 0x56, 0x34, 0x12], false, true), longVal);
+    assert.deepEqual(Long.fromBytes([0x67, 0x45, 0x23, 0x01, 0x78, 0x56, 0x34, 0x12], true, true), ulongVal);
   },
 
   function testToBytes() {
@@ -67,6 +84,7 @@ var tests = [ // BEGIN TEST CASES
     assert.strictEqual(longVal.unsigned, true);
     assert.strictEqual(longVal.toNumber(), 4294967295);
     assert.strictEqual(longVal.toString(), "4294967295");
+    assert.strictEqual(longVal.toBigInt(), 4294967295n);
   },
 
   function testUnsignedConstructHighLow() {
@@ -76,6 +94,7 @@ var tests = [ // BEGIN TEST CASES
     assert.strictEqual(longVal.unsigned, true);
     assert.strictEqual(longVal.toNumber(), 18446744073709551615);
     assert.strictEqual(longVal.toString(), "18446744073709551615");
+    assert.strictEqual(longVal.toBigInt(), 18446744073709551615n);
   },
 
   function testUnsignedConstructNumber() {
@@ -85,6 +104,7 @@ var tests = [ // BEGIN TEST CASES
     assert.strictEqual(longVal.unsigned, true);
     assert.strictEqual(longVal.toNumber(), 18446744073709551615);
     assert.strictEqual(longVal.toString(), "18446744073709551615");
+    assert.strictEqual(longVal.toBigInt(), 18446744073709551615n);
   },
 
   function testUnsignedToSignedUnsigned() {
@@ -110,6 +130,7 @@ var tests = [ // BEGIN TEST CASES
     assert.strictEqual(longVal.unsigned, true);
     assert.strictEqual(longVal.toNumber(), 0);
     assert.strictEqual(longVal.toString(), "0");
+    assert.strictEqual(longVal.toBigInt(), 0n);
   },
 
   function testUnsignedZeroSubSigned() {
@@ -119,12 +140,14 @@ var tests = [ // BEGIN TEST CASES
     assert.strictEqual(longVal.unsigned, true);
     assert.strictEqual(longVal.toNumber(), 18446744073709551615);
     assert.strictEqual(longVal.toString(), "18446744073709551615");
+    assert.strictEqual(longVal.toBigInt(), 18446744073709551615n);
   },
 
   function testUnsignedMaxDivMaxSigned() {
     var longVal = Long.MAX_UNSIGNED_VALUE.div(Long.MAX_VALUE);
     assert.strictEqual(longVal.toNumber(), 2);
     assert.strictEqual(longVal.toString(), "2");
+    assert.strictEqual(longVal.toBigInt(), 2n);
   },
 
   function testUnsignedDivMaxUnsigned() {


### PR DESCRIPTION
There isn't much logic here as BigInt's conversions are being done using its string representations, but I've got tests anyways.

On environments that don't support BigInt, everything else works fine except `toBigInt()`.

Node.js v16.13.1 repl: 
```
> const Long = require('.');
undefined
> Long.fromValue(0).toInt()
0
> Long.fromValue(0).toBigInt()
0n
```

Node.js v8.17.0 repl: 
```
> const Long = require('.');
undefined
> Long.fromValue(0).toInt()
0
> Long.fromValue(0).toBigInt()
ReferenceError: BigInt is not defined
    at Long.toBigInt (/Users/trevorah/Development/long.js/umd/index.js:514:5)
```