### PR TITLE
fix: add `types` to `exports`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "types": "index.d.ts",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./index.js",
       "require": "./umd/index.js"
     }


### PR DESCRIPTION
See https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing