### PR TITLE
New: Typescript 4.7+ compatibility

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -443,4 +443,4 @@ declare class Long {
   xor(other: Long | number | string): Long;
 }
 
-export = Long; // compatible with `import Long from "long"`
+export default Long;


### PR DESCRIPTION
Typescript 4.7^ with mode resolution strategy set to nodenext, is confused about finding export = in d.ts file and complains about default import not being allowed (when imported as import Long from "long") as the heuristics used by typescript to guess seems to be inaccurate. Having export default would help fix this.  