### PR TITLE
Separate ESM/CJS TS definitions, bump esm2umd

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -77,7 +77,11 @@ declare class Long {
   /**
    * Returns a Long representation of the given string, written using the specified radix.
    */
-  static fromString(str: string, unsigned?: boolean | number, radix?: number): Long;
+  static fromString(
+    str: string,
+    unsigned?: boolean | number,
+    radix?: number
+  ): Long;
 
   /**
    * Creates a Long from its byte representation.
@@ -102,7 +106,14 @@ declare class Long {
   /**
    * Converts the specified value to a Long.
    */
-  static fromValue(val: Long | number | string | { low: number, high: number, unsigned: boolean }, unsigned?: boolean): Long;
+  static fromValue(
+    val:
+      | Long
+      | number
+      | string
+      | { low: number; high: number; unsigned: boolean },
+    unsigned?: boolean
+  ): Long;
 
   /**
    * Returns the sum of this and the specified Long.
@@ -443,4 +454,4 @@ declare class Long {
   xor(other: Long | number | string): Long;
 }
 
-export = Long; // compatible with `import Long from "long"`
+export default Long; // compatible with `import Long from "long"`

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "esm2umd": "^0.2.0"
+        "esm2umd": "^0.2.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -518,9 +518,9 @@
       }
     },
     "node_modules/esm2umd": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/esm2umd/-/esm2umd-0.2.0.tgz",
-      "integrity": "sha512-m65W34E0uIOPUcBc2m7+x781OeiwIbsV+3EvpOwQ1Kl4DIUMg7RWpTUwXqn1Uuu5A2AW3OuzUeDTZL87Vgp8hw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/esm2umd/-/esm2umd-0.2.1.tgz",
+      "integrity": "sha512-6xxUuzVJ7/lBOe0+vc4+YDo07ZAXkWrHUKrQWtF3QVSkmaktiHMJIhxHnGYj3pJ0pTvZLSmfhSJp3ntNfHNuJw==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7",
@@ -620,25 +620,16 @@
       }
     },
     "node_modules/json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
       "bin": {
         "json5": "lib/cli.js"
       },
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -1110,9 +1101,9 @@
       "dev": true
     },
     "esm2umd": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/esm2umd/-/esm2umd-0.2.0.tgz",
-      "integrity": "sha512-m65W34E0uIOPUcBc2m7+x781OeiwIbsV+3EvpOwQ1Kl4DIUMg7RWpTUwXqn1Uuu5A2AW3OuzUeDTZL87Vgp8hw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/esm2umd/-/esm2umd-0.2.1.tgz",
+      "integrity": "sha512-6xxUuzVJ7/lBOe0+vc4+YDo07ZAXkWrHUKrQWtF3QVSkmaktiHMJIhxHnGYj3pJ0pTvZLSmfhSJp3ntNfHNuJw==",
       "dev": true,
       "requires": {
         "@babel/core": "^7",
@@ -1182,18 +1173,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
-    },
-    "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -18,12 +18,17 @@
   "license": "Apache-2.0",
   "type": "module",
   "main": "umd/index.js",
-  "types": "index.d.ts",
+  "types": "umd/index.d.ts",
   "exports": {
     ".": {
-      "types": "./index.d.ts",
-      "import": "./index.js",
-      "require": "./umd/index.js"
+      "import": {
+        "default": "./index.js",
+        "types": "./index.d.ts"
+      },
+      "require": {
+        "default": "./umd/index.js",
+        "types": "./umd/index.d.ts"
+      }
     }
   },
   "scripts": {
@@ -40,6 +45,6 @@
     "README.md"
   ],
   "devDependencies": {
-    "esm2umd": "^0.2.0"
+    "esm2umd": "^0.2.1"
   }
 }


### PR DESCRIPTION
Fix for issue #109 as discussed in https://github.com/dcodeIO/long.js/issues/109#issuecomment-1509926947. Also bumped patch version of `esm2umd` to remove 2 security vulnerabilities.