### PR TITLE
Fixed undefined function when using Long.fromValue with a bigInt

### DIFF
--- a/index.js
+++ b/index.js
@@ -1562,7 +1562,7 @@ if (typeof BigInt === "function") {
 
   // Override
   Long.fromValue = function fromValueWithBigInt(value, unsigned) {
-    if (typeof value === "bigint") return fromBigInt(value, unsigned);
+    if (typeof value === "bigint") return Long.fromBigInt(value, unsigned);
     return fromValue(value, unsigned);
   };
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -267,6 +267,15 @@ var tests = [
       assert.strictEqual(unsignedFromUnsigned.toBigInt(), values[i].unsigned);
       var signedFromUnsigned = Long.fromBigInt(values[i].unsigned);
       assert.strictEqual(signedFromUnsigned.toBigInt(), values[i].signed);
+
+      var signedFromSigned = Long.fromValue(values[i].signed);
+      assert.strictEqual(signedFromSigned.toBigInt(), values[i].signed);
+      var unsignedFromSigned = Long.fromValue(values[i].signed, true);
+      assert.strictEqual(unsignedFromSigned.toBigInt(), values[i].unsigned);
+      var unsignedFromUnsigned = Long.fromValue(values[i].unsigned, true);
+      assert.strictEqual(unsignedFromUnsigned.toBigInt(), values[i].unsigned);
+      var signedFromUnsigned = Long.fromValue(values[i].unsigned);
+      assert.strictEqual(signedFromUnsigned.toBigInt(), values[i].signed);
     }
   },
 


### PR DESCRIPTION
Fixed an bug which caused an exception when calling long.fromValue with a bigInt.

Added a test to to catch the bug and show it is fixed.